### PR TITLE
兼容 chngcntr 宏包以便使用者对图、表、公式等进行按章编号

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -59,7 +59,7 @@
 \DeclareBibliographyCategory{cited}
 \AtEveryCitekey{\addtocategory{cited}{\thefield{entrykey}}}
 
-\newtheorem{Theorem}{\hskip 2em 定理}[section]
+\newtheorem{Theorem}{\hskip 2em 定理}
 \newtheorem{Lemma}[Theorem]{\hskip 2em 引理}
 \newtheorem{Corollary}[Theorem]{\hskip 2em 推论}
 \newtheorem{Proposition}[Theorem]{\hskip 2em 命题}
@@ -84,6 +84,11 @@
 \date{\today}
 \keywords{南开大学；毕业论文；模板}
 \keywords*{dark energy model; dynamic analysis}
+
+\counterwithinsection{table}
+\counterwithinsection{figure}
+\counterwithinsection{equation}
+\counterwithinsection{Theorem}
 
 \begin{document}
 

--- a/main.tex
+++ b/main.tex
@@ -33,6 +33,7 @@
 \usepackage{cases}
 \usepackage{multirow}
 \usepackage{enumitem} % 列表格式
+\usepackage{chngcntr} % 编号格式
 
 % \usepackage{tabularx}
 \definecolor{corange}{HTML}{FF9666}
@@ -59,7 +60,7 @@
 \DeclareBibliographyCategory{cited}
 \AtEveryCitekey{\addtocategory{cited}{\thefield{entrykey}}}
 
-\newtheorem{Theorem}{\hskip 2em 定理}
+\newtheorem{Theorem}{\hskip 2em 定理}[section]
 \newtheorem{Lemma}[Theorem]{\hskip 2em 引理}
 \newtheorem{Corollary}[Theorem]{\hskip 2em 推论}
 \newtheorem{Proposition}[Theorem]{\hskip 2em 命题}
@@ -85,10 +86,9 @@
 \keywords{南开大学；毕业论文；模板}
 \keywords*{dark energy model; dynamic analysis}
 
-\counterwithinsection{table}
-\counterwithinsection{figure}
-\counterwithinsection{equation}
-\counterwithinsection{Theorem}
+\counterwithin{table}{section}
+\counterwithin{figure}{section}
+\counterwithin{equation}{section}
 
 \begin{document}
 

--- a/manual.tex
+++ b/manual.tex
@@ -110,11 +110,11 @@ NKThesis 已经调用以下宏包，您无须重新调用。
 
 插图的例子：
 
-\begin{table}
+\begin{figure}
 \centering
 \includegraphics[viewport=0 0 2984 969,width=40mm]{figures/nankaidaxue.pdf}
 \caption{南开大学}
-\end{table}
+\end{figure}
 
 \subsection{字体}
 

--- a/nkuthesis.cls
+++ b/nkuthesis.cls
@@ -63,6 +63,11 @@
 \captionsetup{labelsep=enspace,skip=1pt}
 \RequirePackage{flafter} % 浮动体置于引用后，包含h选项后似乎不生效
 \RequirePackage[section]{placeins} % 浮动体不跨节
+\newcommand{\english@section@counter}{\arabic{section}}
+\newcommand{\counterwithinsection}[1]{
+	\@addtoreset{#1}{section}
+	\csdef{the#1}{\english@section@counter.\arabic{#1}}
+}
 
 % 超链接、PDF书签属性（教务处格式未要求）
 \RequirePackage[hidelinks,pdfa,pdfusetitle,bookmarksnumbered]{hyperref}
@@ -186,15 +191,20 @@
 
 % 附录
 \RenewDocumentCommand{\appendix}{s}{
-	\setcounter{section}{0}
-	\setcounter{subsection}{0}
-	\renewcommand{\thesection}{\Alph{section}}
-	\addtocontents{toc}{\protect\setcounter{tocdepth}{1}}%
-	\titleformat{\section}{\centering\zihao{4}\sffamily}
-		{附\hspace{1em}录\Alph{section}：}{0em}{}
-	\titlecontents{section}[0em]{\zihao{-3}}{附录\thecontentslabel：}{}
-		{\content@filler\contentspage}
-	\IfBooleanT{#1}{\nolabel@section{4}[附录]{附\hspace{1em}录}}
+	\IfBooleanTF{#1}{
+		\nolabel@section{4}[附录]{附\hspace{1em}录}
+		\renewcommand{\english@section@counter}{A}
+	}{
+		\setcounter{section}{0}
+		\setcounter{subsection}{0}
+		\renewcommand{\thesection}{\Alph{section}}
+		\addtocontents{toc}{\protect\setcounter{tocdepth}{1}}%
+		\titleformat{\section}{\centering\zihao{4}\sffamily}
+			{附\hspace{1em}录\Alph{section}：}{0em}{}
+		\titlecontents{section}[0em]{\zihao{-3}}{附录\thecontentslabel：}{}
+			{\content@filler\contentspage}
+		\renewcommand{\english@section@counter}{\Alph{section}}
+	}
 }
 
 % 参考文献

--- a/nkuthesis.cls
+++ b/nkuthesis.cls
@@ -39,11 +39,6 @@
 \RequirePackage{calc}
 \setcounter{secnumdepth}{5}
 \newcommand{\sectionbreak}{\newpage\vspace*{0pt}}
-\renewcommand{\thesection}{\chinese{section}}
-\renewcommand{\thesubsection}{\chinese{subsection}}
-\renewcommand{\thesubsubsection}{\chinese{subsubsection}}
-\renewcommand{\theparagraph}{\chinese{paragraph}}
-\renewcommand{\thesubparagraph}{\chinese{subparagraph}}
 \titleformat{\section}{\centering\zihao{-3}\sffamily}{\chinese{section}、}{0em}{}
 \titleformat{\subsection}{\centering\zihao{4}\sffamily}{（\chinese{subsection}）}{0em}{}
 \titleformat{\subsubsection}{\zihao{-4}\sffamily}{\arabic{subsubsection}.}{0.5em}{}
@@ -63,11 +58,6 @@
 \captionsetup{labelsep=enspace,skip=1pt}
 \RequirePackage{flafter} % 浮动体置于引用后，包含h选项后似乎不生效
 \RequirePackage[section]{placeins} % 浮动体不跨节
-\newcommand{\english@section@counter}{\arabic{section}}
-\newcommand{\counterwithinsection}[1]{
-	\@addtoreset{#1}{section}
-	\csdef{the#1}{\english@section@counter.\arabic{#1}}
-}
 
 % 超链接、PDF书签属性（教务处格式未要求）
 \RequirePackage[hidelinks,pdfa,pdfusetitle,bookmarksnumbered]{hyperref}
@@ -183,27 +173,26 @@
 \setcounter{tocdepth}{2}
 \newcommand{\content@filler}{~\titlerule*[0.96em]{\CJKfamily{fb@song}…}}
 \titlecontents{section}[0em]{\zihao{-3}}
-	{\thecontentslabel、}{}{\content@filler\contentspage}
+	{\zhnumber{\thecontentslabel}、}{}{\content@filler\contentspage}
+\renewcommand{\thesubsection}{\arabic{subsection}}
 \titlecontents{subsection}[2em]{\zihao{4}}
-	{（\thecontentslabel）}{}{\content@filler\contentspage}
+	{（\zhnumber{\thecontentslabel}）}{}{\content@filler\contentspage}
 \renewcommand{\tableofcontents}
 	{\nolabel@section*{3}[目录]{目\hspace{1em}录}\@starttoc{toc}\clearpage}
 
 % 附录
 \RenewDocumentCommand{\appendix}{s}{
-	\IfBooleanTF{#1}{
+	\setcounter{section}{0}
+	\setcounter{subsection}{0}
+	\renewcommand{\thesection}{\Alph{section}}
+	\addtocontents{toc}{\protect\setcounter{tocdepth}{1}}%
+	\titleformat{\section}{\centering\zihao{4}\sffamily}
+		{附\hspace{1em}录\Alph{section}：}{0em}{}
+	\titlecontents{section}[0em]{\zihao{-3}}{附录\thecontentslabel：}{}
+		{\content@filler\contentspage}
+	\IfBooleanT{#1}{
+		\stepcounter{section}
 		\nolabel@section{4}[附录]{附\hspace{1em}录}
-		\renewcommand{\english@section@counter}{A}
-	}{
-		\setcounter{section}{0}
-		\setcounter{subsection}{0}
-		\renewcommand{\thesection}{\Alph{section}}
-		\addtocontents{toc}{\protect\setcounter{tocdepth}{1}}%
-		\titleformat{\section}{\centering\zihao{4}\sffamily}
-			{附\hspace{1em}录\Alph{section}：}{0em}{}
-		\titlecontents{section}[0em]{\zihao{-3}}{附录\thecontentslabel：}{}
-			{\content@filler\contentspage}
-		\renewcommand{\english@section@counter}{\Alph{section}}
 	}
 }
 


### PR DESCRIPTION
- 处于正文时，`\thesection` 定义为 `\arabic{secion}`
- 处于单标题附录，`\thesection` 定义为 `A`
- 处于多标题附录，`\thesection` 定义为 `\Alph{secion}`