### PR TITLE
修改脚注样式

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -127,7 +127,7 @@ Since 1998, two independent supernova research groups have discovered that the u
 
 \include{manual}
 \appendix*
-单标题附录
+单标题附录\footnote{脚注}
 
 \appendix
 \section{多标题附录}

--- a/nkuthesis.cls
+++ b/nkuthesis.cls
@@ -48,9 +48,6 @@
 % 注释
 \RequirePackage[perpage,bottom]{footmisc}
 \renewcommand{\thefootnote}{\ding{\numexpr171+\value{footnote}}} % 仅 1-10 有效
-\RequirePackage{etoolbox}
-\patchcmd\@makefntext{{\hss\@makefnmark}}
-	{{\hss\hbox{\normalfont\zihao{-5}\@thefnmark}}\enspace}{}{\fail}
 
 % 图、表
 \RequirePackage{caption}
@@ -92,6 +89,7 @@
 	{\renewcommand{\zh@title}{#2}\hypersetup{pdftitle={#2}}}}
 
 % 封面
+\RequirePackage{etoolbox}
 \newlength\topulineparbox@totalheight
 \newcommand\ul@t@parbox[2]{{%
 	\hbadness=10000 % 禁用此处 "underfull hbox" 提示

--- a/nkuthesis.cls
+++ b/nkuthesis.cls
@@ -48,6 +48,8 @@
 % 注释
 \RequirePackage[perpage,bottom]{footmisc}
 \renewcommand{\thefootnote}{\ding{\numexpr171+\value{footnote}}} % 仅 1-10 有效
+\RequirePackage{etoolbox}
+\patchcmd\@makefntext{#1}{\enspace{}#1}{}{\fail}
 
 % 图、表
 \RequirePackage{caption}

--- a/nkuthesis.cls
+++ b/nkuthesis.cls
@@ -91,7 +91,6 @@
 	{\renewcommand{\zh@title}{#2}\hypersetup{pdftitle={#2}}}}
 
 % 封面
-\RequirePackage{etoolbox}
 \newlength\topulineparbox@totalheight
 \newcommand\ul@t@parbox[2]{{%
 	\hbadness=10000 % 禁用此处 "underfull hbox" 提示


### PR DESCRIPTION
脚注恢复为上标样式，因为word中脚注编号在脚注区也是上标